### PR TITLE
s/node/service

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -13,7 +13,7 @@
 //!
 //!
 
-use devices::*;
+use services::*;
 use selector::*;
 use values::Value;
 use util::Id;
@@ -21,8 +21,8 @@ use util::Id;
 /// An error produced by one of the APIs in this module.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Error {
-    /// There is no such node connected to the Foxbox, even indirectly.
-    NoSuchNode(Id<NodeId>),
+    /// There is no such service connected to the Foxbox, even indirectly.
+    NoSuchService(Id<ServiceId>),
 
     /// There is no such getter channel connected to the Foxbox, even indirectly.
     NoSuchGetter(Id<Getter>),
@@ -59,20 +59,20 @@ pub enum WatchEvent {
 
 /// A handle to the public API.
 pub trait API: Send {
-    /// Get the metadata on nodes matching some conditions.
+    /// Get the metadata on services matching some conditions.
     ///
-    /// A call to `API::get_nodes(vec![req1, req2, ...])` will return
-    /// the metadata on all nodes matching _either_ `req1` or `req2`
+    /// A call to `API::get_services(vec![req1, req2, ...])` will return
+    /// the metadata on all services matching _either_ `req1` or `req2`
     /// or ...
     ///
     /// # REST API
     ///
-    /// `GET /api/v1/nodes`
+    /// `GET /api/v1/services`
     ///
     /// ## Requests
     ///
-    /// Any JSON that can be deserialized to a `Vec<NodeSelector>`. See
-    /// the implementation of `NodeSelector` for details.
+    /// Any JSON that can be deserialized to a `Vec<ServiceSelector>`. See
+    /// the implementation of `ServiceSelector` for details.
     ///
     /// ### Example
     ///
@@ -102,20 +102,20 @@ pub trait API: Send {
     ///
     /// ## Success
     ///
-    /// A JSON representing an array of `Node`. See the implementation
-    /// of `Node` for details.
+    /// A JSON representing an array of `Service`. See the implementation
+    /// of `Service` for details.
     ///
     /// ### Example
     ///
     /// ```json
     /// [{
     ///   "tags": ["entrance", "door", "somevendor"],
-    ///   "id: "some-node-id",
+    ///   "id: "some-service-id",
     ///   "getters": [],
     ///   "setters": [
     ///     "tags": [...],
     ///     "id": "some-channel-id",
-    ///     "node": "some-node-id",
+    ///     "service": "some-service-id",
     ///     "last_seen": "some-date",
     ///     "mechanism": {
     ///       "Setter":  {
@@ -129,25 +129,25 @@ pub trait API: Send {
     ///   ]
     /// }]
     /// ```
-    fn get_nodes(&self, &Vec<NodeSelector>) -> Vec<Node>;
+    fn get_services(&self, &Vec<ServiceSelector>) -> Vec<Service>;
 
-    /// Label a set of nodes with a set of tags.
+    /// Label a set of services with a set of tags.
     ///
-    /// A call to `API::put_node_tag(vec![req1, req2, ...], vec![tag1,
-    /// ...])` will label all the nodes matching _either_ `req1` or
-    /// `req2` or ... with `tag1`, ... and return the number of nodes
+    /// A call to `API::put_service_tag(vec![req1, req2, ...], vec![tag1,
+    /// ...])` will label all the services matching _either_ `req1` or
+    /// `req2` or ... with `tag1`, ... and return the number of services
     /// matching any of the selectors.
     ///
-    /// Some of the nodes may already be labelled with `tag1`, or
+    /// Some of the services may already be labelled with `tag1`, or
     /// `tag2`, ... They will not change state. They are counted in
     /// the resulting `usize` nevertheless.
     ///
-    /// Note that this call is _not live_. In other words, if nodes
+    /// Note that this call is _not live_. In other words, if services
     /// are added after the call, they will not be affected.
     ///
     /// # REST API
     ///
-    /// `POST /api/v1/nodes/tag`
+    /// `POST /api/v1/services/tag`
     ///
     /// ## Getters
     ///
@@ -155,7 +155,7 @@ pub trait API: Send {
     ///
     /// ```ignore
     /// {
-    ///   set: Vec<NodeSelector>,
+    ///   set: Vec<ServiceSelector>,
     ///   tags: Vec<String>,
     /// }
     /// ```
@@ -168,25 +168,25 @@ pub trait API: Send {
     /// ## Success
     ///
     /// A JSON string representing a number.
-    fn put_node_tag(&self, set: &Vec<NodeSelector>, tags: &Vec<String>) -> usize;
+    fn add_service_tag(&self, set: &Vec<ServiceSelector>, tags: &Vec<String>) -> usize;
 
-    /// Remove a set of tags from a set of nodes.
+    /// Remove a set of tags from a set of services.
     ///
-    /// A call to `API::delete_node_tag(vec![req1, req2, ...], vec![tag1,
-    /// ...])` will remove from all the nodes matching _either_ `req1` or
-    /// `req2` or ... all of the tags `tag1`, ... and return the number of nodes
+    /// A call to `API::delete_service_tag(vec![req1, req2, ...], vec![tag1,
+    /// ...])` will remove from all the services matching _either_ `req1` or
+    /// `req2` or ... all of the tags `tag1`, ... and return the number of services
     /// matching any of the selectors.
     ///
-    /// Some of the nodes may not be labelled with `tag1`, or `tag2`,
+    /// Some of the services may not be labelled with `tag1`, or `tag2`,
     /// ... They will not change state. They are counted in the
     /// resulting `usize` nevertheless.
     ///
-    /// Note that this call is _not live_. In other words, if nodes
+    /// Note that this call is _not live_. In other words, if services
     /// are added after the call, they will not be affected.
     ///
     /// # REST API
     ///
-    /// `DELETE /api/v1/nodes/tag`
+    /// `DELETE /api/v1/services/tag`
     ///
     /// ## Getters
     ///
@@ -194,7 +194,7 @@ pub trait API: Send {
     ///
     /// ```ignore
     /// {
-    ///   set: Vec<NodeSelector>,
+    ///   set: Vec<ServiceSelector>,
     ///   tags: Vec<String>,
     /// }
     /// ```
@@ -207,8 +207,8 @@ pub trait API: Send {
     /// ## Success
     ///
     /// A JSON representing a number.
-    fn delete_node_tag(&self, set: &Vec<NodeSelector>, tags: String) -> usize;
-    
+    fn remove_service_tag(&self, set: &Vec<ServiceSelector>, tags: String) -> usize;
+
     /// Get a list of getters matching some conditions
     ///
     /// # REST API
@@ -261,8 +261,8 @@ pub trait API: Send {
     /// ## Success
     ///
     /// A JSON representing a number.
-    fn put_getter_tag(&self, &Vec<GetterSelector>, &Vec<String>) -> usize;
-    fn put_setter_tag(&self, &Vec<SetterSelector>, &Vec<String>) -> usize;
+    fn add_getter_tag(&self, &Vec<GetterSelector>, &Vec<String>) -> usize;
+    fn add_setter_tag(&self, &Vec<SetterSelector>, &Vec<String>) -> usize;
 
     /// Remove a set of tags from a set of channels.
     ///
@@ -308,8 +308,8 @@ pub trait API: Send {
     /// ## Success
     ///
     /// A JSON representing a number.
-    fn delete_getter_tag(&self, &Vec<GetterSelector>, &Vec<String>) -> usize;
-    fn delete_setter_tag(&self, &Vec<SetterSelector>, &Vec<String>) -> usize;
+    fn remove_getter_tag(&self, &Vec<GetterSelector>, &Vec<String>) -> usize;
+    fn remove_setter_tag(&self, &Vec<SetterSelector>, &Vec<String>) -> usize;
 
     /// Read the latest value from a set of channels
     ///
@@ -323,7 +323,7 @@ pub trait API: Send {
     /// # REST API
     ///
     /// `POST /api/v1/channels/value`
-    fn put_channel_value(&self, &Vec<SetterSelector>, Value) -> Vec<(Id<Setter>, Result<(), Error>)>;
+    fn set_channel_value(&self, &Vec<SetterSelector>, Value) -> Vec<(Id<Setter>, Result<(), Error>)>;
 
     /// Watch for any change
     ///
@@ -346,7 +346,7 @@ pub struct WatchOptions {
     /// If `true`, watch as new values become available.
     pub should_watch_values: bool,
 
-    /// If `true`, watch as nodes are connected/disconnected.
+    /// If `true`, watch as services are connected/disconnected.
     pub should_watch_topology: bool,
 
     /// Make sure that we can't instantiate from another crate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 //! # Taxonomy
 //!
-//! A network of Connected Devices is composed of `Node`s. Each node
+//! A network of Connected Devices is composed of `Service`s. Each service
 //! is essentially a collection of `Service<Input>`s, which provide
 //! data from the devices for use by applications, and
 //! `Service<Output>`s, which give applications the ability to send
@@ -14,11 +14,11 @@
 //! that can be sent to/received from a service. The core list of
 //! `ServiceKind` is hardcoded, but open for extensions.
 //!
-//! 
+//!
 //!
 //! # Example
 //!
-//! The FoxBox itelf is a `Node`, which may offer the following services:
+//! The FoxBox itelf is a `Service`, which may offer the following services:
 //!
 //! - `Service<Input>`: `ServiceKind::CurrentTime`, `ServiceKind::CurrentTimeOfDay`, ...
 //! - `Service<Output>`: `ServiceKind::SMS`.
@@ -26,7 +26,7 @@
 //!
 //! # Example
 //!
-//! A light is a `Node`, which may offer:
+//! A light is a `Service`, which may offer:
 //!
 //! - a `Service<Output>` with `ServiceKind::OnOff`, to turn the light on or off;
 //! - a `Service<Input>` with `ServiceKind::OnOff`, to determine whether the light is on or off;
@@ -40,7 +40,7 @@ extern crate serde;
 extern crate serde_json;
 
 /// Metadata on devices
-pub mod devices;
+pub mod services;
 
 /// Public-facing API
 pub mod api;

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -21,7 +21,7 @@ fn merge<T>(mut a: Vec<T>, mut b: Vec<T>) -> Vec<T> where T: Ord {
 ///
 /// ```
 /// use foxbox_taxonomy::selector::*;
-/// use foxbox_taxonomy::devices::*;
+/// use foxbox_taxonomy::services::*;
 ///
 /// let selector = ServiceSelector::new()
 ///   .with_tags(vec!["entrance".to_owned()])
@@ -110,7 +110,7 @@ impl ServiceSelector {
 ///
 /// ```
 /// use foxbox_taxonomy::selector::*;
-/// use foxbox_taxonomy::devices::*;
+/// use foxbox_taxonomy::services::*;
 /// use foxbox_taxonomy::util::Id;
 ///
 /// let selector = GetterSelector::new()

--- a/src/services.rs
+++ b/src/services.rs
@@ -14,33 +14,33 @@ use serde::de::{Deserialize, Deserializer, Error};
 
 
 /// A marker for Id.
-/// Only useful for writing `Id<NodeId>`.
+/// Only useful for writing `Id<ServiceId>`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Hash, Eq)]
-pub struct NodeId;
+pub struct ServiceId;
 
-/// Metadata on a node. A node is a device or collection of devices
-/// that may offer services. The FoxBox itself a node offering
+/// Metadata on a service. A service is a device or collection of devices
+/// that may offer services. The FoxBox itself a service offering
 /// services such as a clock, communication with the user through her
 /// smart devices, etc.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Node {
-    /// Tags describing the node.
+pub struct Service {
+    /// Tags describing the service.
     ///
     /// These tags can be set by the user, adapters or
-    /// applications. They are used by applications to find nodes and
+    /// applications. They are used by applications to find services and
     /// services.
     ///
-    /// For instance, a user may set tag "entrance" to all nodes
-    /// placed in the entrance of his house, or a tag "blue" to a node
+    /// For instance, a user may set tag "entrance" to all services
+    /// placed in the entrance of his house, or a tag "blue" to a service
     /// controlling blue lights. An adapter may set tags "plugged" or
     /// "battery" to devices that respectively depend on a plugged
     /// power source or on a battery.
     pub tags: Vec<String>,
 
-    /// An id unique to this node.
-    pub id: Id<NodeId>,
+    /// An id unique to this service.
+    pub id: Id<ServiceId>,
 
-    /// Channels connected directly to this node.
+    /// Channels connected directly to this service.
     pub getters: Vec<Channel<Getter>>,
     pub setters: Vec<Channel<Setter>>,
 
@@ -224,7 +224,7 @@ impl IOMechanism for Setter {
 /// leave a device. Note that channels support either a single kind
 /// of getter or a single kind of setter. Devices that support both
 /// getters or setters, or several kinds of getters, or several kinds of
-/// setters, are represented as nodes containing several channels.
+/// setters, are represented as services containing several channels.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Channel<IO> where IO: IOMechanism {
     /// Tags describing the channel.
@@ -239,8 +239,8 @@ pub struct Channel<IO> where IO: IOMechanism {
     /// An id unique to this channel.
     pub id: Id<IO>,
 
-    /// The node owning this channel.
-    pub node: Id<NodeId>,
+    /// The service owning this channel.
+    pub service: Id<ServiceId>,
 
     /// The update mechanism for this channel.
     pub mechanism: IO,

--- a/src/values.rs
+++ b/src/values.rs
@@ -40,7 +40,7 @@ pub enum Type {
     TimeStamp,
 
     Temperature,
-    String, 
+    String,
     ///
     /// ...
     ///


### PR DESCRIPTION
I finally found time to look at that. I like it a lot!
I did a s/node/service because I felt that "node" was too abstract. I'm still not a huge fan of "channel" but I don't have a better proposal ("endpoint" doesn't seem better to me).

Bool values are not great in general. Should we rather enforce enums (eg. `get_value("door_sensor/state") -> Enum { Closed, Open}` instead of `-> bool`).

Current implementation is to select services/channel that have all the specified tags. Should we also support "one or several of"?Although that can be worked around by adding more specific tags, so no big deal for now.
