### PR TITLE
Removed fields push, poll, trigger.

### DIFF
--- a/src/selector.rs
+++ b/src/selector.rs
@@ -219,16 +219,6 @@ pub struct GetterSelector {
     #[serde(default)]
     pub kind: Exactly<ChannelKind>,
 
-    /// If `Some(r)`, restrict results to channels that support polling
-    /// with the acceptable period.
-    #[serde(default)]
-    pub poll: Option<Period>,
-
-    /// If `Some(r)`, restrict results to channels that support trigger
-    /// with the acceptable period.
-    #[serde(default)]
-    pub trigger: Option<Period>,
-
     /// Make sure that we can't instantiate from another crate.
     #[serde(default, skip_serializing)]
     private: (),
@@ -271,24 +261,6 @@ impl GetterSelector {
         }
     }
 
-    /// Restrict to channels that support polling with the acceptable
-    /// period
-    pub fn with_poll(self, period: Period) -> Self {
-        GetterSelector {
-            poll: Period::and_option(self.poll, Some(period)),
-            .. self
-        }
-    }
-
-    /// Restrict to channels that support trigger with the acceptable
-    /// period
-    pub fn with_trigger(self, period: Period) -> Self {
-        GetterSelector {
-            trigger: Period::and_option(self.trigger, Some(period)),
-            .. self
-        }
-    }
-
     /// Restrict to channels that are accepted by two selector.
     pub fn and(self, other: Self) -> Self {
         GetterSelector {
@@ -296,8 +268,6 @@ impl GetterSelector {
             parent: self.parent.and(other.parent),
             tags: self.tags.union(&other.tags).cloned().collect(),
             kind: self.kind.and(other.kind),
-            poll: Period::and_option(self.poll, other.poll),
-            trigger: Period::and_option(self.trigger, other.trigger),
             private: (),
         }
     }
@@ -311,12 +281,6 @@ impl GetterSelector {
             return false;
         }
         if !self.kind.matches(&channel.mechanism.kind) {
-            return false;
-        }
-        if !Period::matches_option(&self.poll, &channel.mechanism.poll) {
-            return false;
-        }
-        if !Period::matches_option(&self.trigger, &channel.mechanism.trigger) {
             return false;
         }
         if !has_selected_tags(&self.tags, &channel.tags) {
@@ -352,11 +316,6 @@ pub struct SetterSelector {
     /// of kind `k`.
     #[serde(default)]
     pub kind: Exactly<ChannelKind>,
-
-    /// If `Some(r)`, restrict results to channels that support pushing
-    /// with the acceptable period.
-    #[serde(default)]
-    pub push: Option<Period>,
 
     /// Make sure that we can't instantiate from another crate.
     #[serde(default, skip_serializing)]
@@ -401,15 +360,6 @@ impl SetterSelector {
         }
     }
 
-    /// Restrict to channels that support push with the acceptable
-    /// period
-    pub fn with_push(self, period: Period) -> Self {
-        SetterSelector {
-            push: Period::and_option(self.push, Some(period)),
-            .. self
-        }
-    }
-
     /// Restrict results to channels that are accepted by two selector.
     pub fn and(self, other: Self) -> Self {
         SetterSelector {
@@ -417,7 +367,6 @@ impl SetterSelector {
             parent: self.parent.and(other.parent),
             tags: self.tags.union(&other.tags).cloned().collect(),
             kind: self.kind.and(other.kind),
-            push: Period::and_option(self.push, other.push),
             private: (),
         }
     }
@@ -431,9 +380,6 @@ impl SetterSelector {
             return false;
         }
         if !self.kind.matches(&channel.mechanism.kind) {
-            return false;
-        }
-        if !Period::matches_option(&self.push, &channel.mechanism.push) {
             return false;
         }
         if !has_selected_tags(&self.tags, &channel.tags) {

--- a/src/services.rs
+++ b/src/services.rs
@@ -200,36 +200,6 @@ pub struct Getter {
     /// The kind of value that can be obtained from this channel.
     pub kind: ChannelKind,
 
-    /// If `Some(duration)`, this channel can be polled, i.e. it
-    /// will respond when the FoxBox requests the latest value.
-    /// Parameter `duration` indicates the smallest interval
-    /// between two updates.
-    ///
-    /// Otherwise, the channel cannot be polled and will push
-    /// data to the FoxBox when it is available.
-    ///
-    /// # Examples
-    ///
-    /// - Long-running pollution or humidity sensors typically
-    ///   do not accept requests and rather send batches of
-    ///   data every 24h.
-    #[serde(default)]
-    pub poll: Option<Duration>,
-
-    /// If `Some(duration)`, this channel can send the data to
-    /// the FoxBox whenever it is updated. Parameter `duration`
-    /// indicates the smallest interval between two updates.
-    ///
-    /// Otherwise, the channel cannot send data to the FoxBox
-    /// and needs to be polled.
-    #[serde(default)]
-    pub trigger: Option<Duration>,
-
-    /// If `true`, this channel supports watching for specific
-    /// changes.
-    #[serde(default)]
-    pub watch: bool,
-
     /// Date at which the latest value was received, whether through
     /// polling or through a trigger.
     #[serde(default)]
@@ -244,11 +214,6 @@ impl IOMechanism for Getter {
 pub struct Setter {
     /// The kind of value that can be sent to this channel.
     pub kind: ChannelKind,
-
-    /// If `Some(duration)`, this channel supports pushing,
-    /// i.e. the FoxBox can send values.
-    #[serde(default)]
-    pub push: Option<Duration>,
 
     /// Date at which the latest value was sent to the channel.
     #[serde(default)]


### PR DESCRIPTION
These fields are unused and ill-defined. We may reintroduce them
later, once we have a clearer idea.
