### PR TITLE
Changed the format of TargetMap

### DIFF
--- a/src/manager.rs
+++ b/src/manager.rs
@@ -9,7 +9,7 @@ pub use backend::WatchGuard;
 use backend::{ Op, AdapterManagerState };
 use adapter::{ Adapter, AdapterManagerHandle };
 
-use api::{ API, Error, ResultMap, WatchEvent };
+use api::{ API, Error, ResultMap, TargetMap, WatchEvent };
 use selector::*;
 use services::*;
 use values::{ Range, Value };
@@ -350,7 +350,7 @@ impl API for AdapterManager {
     }
 
     /// Send a bunch of values to a set of channels
-    fn send_values(&self, keyvalues: Vec<(Vec<SetterSelector>, Value)>) ->
+    fn send_values(&self, keyvalues: TargetMap<SetterSelector, Value>) ->
         ResultMap<Id<Setter>, (), Error>
     {
         let (tx, rx) = channel();
@@ -361,7 +361,7 @@ impl API for AdapterManager {
     }
 
     /// Watch for any change
-    fn watch_values(&self, watch: Vec<(Vec<GetterSelector>, Exactly<Range>)>,
+    fn watch_values(&self, watch: TargetMap<GetterSelector, Exactly<Range>>,
         on_event: Box<ExtSender<WatchEvent>>) -> Self::WatchGuard
     {
         let (tx, rx) = channel();

--- a/src/services.rs
+++ b/src/services.rs
@@ -8,7 +8,7 @@
 
 use parse::*;
 use values::*;
-pub use util::*;
+pub use util::{ Exactly, Id, AdapterId, ServiceId, KindId, TagId, VendorId };
 
 use serde::ser::{ Serialize, Serializer };
 use serde::de::{ Deserialize, Deserializer, Error };

--- a/src/util.rs
+++ b/src/util.rs
@@ -112,6 +112,35 @@ impl<T> Deserialize for Phantom<T> {
     }
 }
 
+
+/// A bunch of results coming from different sources.
+pub type ResultMap<K, T, E> = HashMap<K, Result<T, E>>;
+
+/// A bunch of instructions, going to different targets.
+pub type TargetMap<K, T> = Vec<Targetted<K, T>>;
+
+#[derive(Clone)]
+pub struct Targetted<K, T> where K: Clone, T: Clone {
+    pub select: Vec<K>,
+    pub payload: T
+}
+impl<K, T> Default for Targetted<K, T> where T: Default + Clone, K: Clone {
+    fn default() -> Self {
+        Targetted {
+            select: vec![],
+            payload: T::default()
+        }
+    }
+}
+impl<K, T> Targetted<K, T> where K: Clone, T: Clone {
+    pub fn new(select: Vec<K>, payload: T) -> Self {
+        Targetted {
+            select: select,
+            payload: payload
+        }
+    }
+}
+
 /// A unique id for values of a given kind.
 ///
 /// # Performance
@@ -235,9 +264,6 @@ impl<T, U> ToJSON for HashMap<Id<U>, T> where T: ToJSON {
     }
 }
 
-
-/// A bunch of results grouped in an array of (key, result).
-pub type ResultSet<I, T, E> = HashMap<I, Result<T, E>>;
 
 /// By default, the (de)serialization of trivial enums by Serde is surprising, e.g.
 /// in JSON,  `enum Foo {A, B, C}` will produce `{"\"A\": []"}` for `A`, where `"\"A\""`


### PR DESCRIPTION
TargetMap<K, T> used to be Vec<(Vec<K>, T)>, which proved hard to
understand and debug while writing JSON. This patch rewrites
TargetMap<K, T> as Vec<Targetted<K, T>> and implements parsing of this
type.

Oh, and a few more tests, along the way.
