### PR TITLE
Resolves #80 - Fixing race condition for WatchEvent::{GetterAdded, GetterRemoved}

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -478,6 +478,10 @@ impl State {
                         continue;
                     }
                 };
+                if watcher.is_dropped.load(Ordering::Relaxed) {
+                    // The guard has been dropped, we don't care anymore.
+                    continue;
+                }
 
                 // We need to disconnect the watcher if either the channel is being removed
                 // or it doesn't match anymore any of the selectors for the watchers
@@ -525,6 +529,10 @@ impl State {
                     for watcher in &mut self.watchers.lock().unwrap().watchers.values() {
                         if watcher.guards.borrow().contains_key(&id) {
                             // The watcher already matches this getter.
+                            continue;
+                        }
+                        if watcher.is_dropped.load(Ordering::Relaxed) {
+                            // The guard has been dropped, we don't care anymore.
                             continue;
                         }
                         for targetted in &watcher.watch {

--- a/tests/test_manager.rs
+++ b/tests/test_manager.rs
@@ -1414,9 +1414,6 @@ fn test_watch() {
 
         println!("* We stop receiving value change notifications once we have dropped the guard.");
         drop(guard);
-
-        // Wait until all messages have been handled.
-        thread::sleep(std::time::Duration::new(1, 0));
         assert_matches!(rx_watch.try_recv(), Err(_));
 
         tweak_1(Tweak::InjectGetterValue(getter_id_1_1.clone(), Ok(Some(Value::OnOff(OnOff::On)))));


### PR DESCRIPTION
Turns out that the back-end could still send these events shortly after the guard was dropped.

Now using field `is_dropped` – which was designed for this, after all – to determine whether the guard has already been dropped, in which case we don't send the events.
