### PR TITLE
Add code coverage on unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,18 @@
 language: rust
+
+addons:
+  apt:
+    packages:
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev
+
+script:
+  - cargo build
+  # FIXME: We currently execute unit tests twice. Once with and the other time,
+  # without the dead code in the binary.
+  - cargo test -- --nocapture
+  - $TRAVIS_BUILD_DIR/tools/execute-unit-tests-with-coverage
+
 rust:
   - nightly-2016-04-10

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # FoxBox Taxonomy
 
 [![Build Status](https://api.travis-ci.org/fxbox/taxonomy.svg?branch=master)](https://travis-ci.org/fxbox/taxonomy)
+[![Coverage Status](https://coveralls.io/repos/github/fxbox/taxonomy/badge.svg?branch=master)](https://coveralls.io/github/fxbox/taxonomy?branch=master)
 [![Clippy Linting Result](http://clippy.bashy.io/github/fxbox/taxonomy/master/badge.svg)](http://clippy.bashy.io/github/fxbox/taxonomy/master/log)
 
 Specifications-as-code for the high-level API to manipulate devices in

--- a/tools/execute-unit-tests-with-coverage
+++ b/tools/execute-unit-tests-with-coverage
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Warning: kcov is a Linux only tool
+
+set -ex
+
+CURRENT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PROJECT_HOME="$CURRENT_PATH/.."
+PROJECT_NAME=$(sed --quiet 's/^name *= *"\(.*\)"$/\1/p' $PROJECT_HOME/Cargo.toml)
+PROJECT_BINARY_LOCATION="$PROJECT_HOME/target/debug"
+
+KCOV_VERSION="30"
+KCOV_TEMP="$PROJECT_HOME/target/kcov"
+KCOV_COMPILE_HOME="$KCOV_TEMP/kcov-$KCOV_VERSION"
+KCOV_BINARY="$KCOV_TEMP/kcov"
+
+
+get_prebuilt() {
+    local ubuntu_version="$1"
+    curl --location --output "$KCOV_BINARY" \
+      "https://github.com/JohanLorenzo/kcov/releases/download/v$KCOV_VERSION/kcov_$ubuntu_version"
+    chmod +x "$KCOV_BINARY"
+}
+
+get_and_compile_kcov_locally() {
+  curl --location --output "$KCOV_TEMP/kcov.tar.gz" \
+    "https://github.com/SimonKagstrom/kcov/archive/v$KCOV_VERSION.tar.gz"
+  tar xvf "$KCOV_TEMP/kcov.tar.gz" --directory="$KCOV_TEMP"
+  cd "$KCOV_COMPILE_HOME"
+  cmake .
+  make
+  cp "src/kcov" "$KCOV_BINARY"
+  cd -
+}
+
+get_kcov() {
+    mkdir -p "$KCOV_TEMP"
+
+    local ubuntu_version=$(lsb_release --codename --short)
+    if [[ "$ubuntu_version" == 'precise' || "$ubuntu_version" == 'trusty' ]] ; then
+        get_prebuilt "$ubuntu_version"
+    else
+        get_and_compile_kcov_locally
+    fi
+}
+
+compile_project_with_dead_code() {
+  RUSTFLAGS="-C link-dead-code" cargo test --no-run
+}
+
+run_tests_and_coverage() {
+  PROJECT_UNIT_TEST_BINARY=$(find "$PROJECT_BINARY_LOCATION" -maxdepth 1 -executable -name "$PROJECT_NAME"-\*)
+
+  RUST_BACKTRACE=1 "$KCOV_BINARY" \
+    --exclude-path="${CARGO_HOME:=~/.cargo},\
+                    $PROJECT_HOME/src/stubs,\
+                    $PROJECT_HOME/target" \
+    --coveralls-id="${TRAVIS_JOB_ID:=no-job-id}" \
+    "$PROJECT_HOME/target/coverage-report/" \
+    "$PROJECT_UNIT_TEST_BINARY"
+}
+
+
+if ! [ -f "$KCOV_BINARY" ] ; then
+  get_kcov
+fi
+
+compile_project_with_dead_code
+run_tests_and_coverage


### PR DESCRIPTION
Follow up of #59. #59 was deprecated because rust up was not needed anymore. Moreover Github doesn't to reopen the PR because `the branch was either force pushed or recreated`.
